### PR TITLE
Fix default values for hideConferenceSubject/-Timer

### DIFF
--- a/config.js
+++ b/config.js
@@ -1031,10 +1031,10 @@ var config = {
     // },
 
     // Hides the conference subject
-    // hideConferenceSubject: true,
+    // hideConferenceSubject: false,
 
     // Hides the conference timer.
-    // hideConferenceTimer: true,
+    // hideConferenceTimer: false,
 
     // Hides the recording label
     // hideRecordingLabel: false,


### PR DESCRIPTION
The default values stated in the commented lines in config file are both true for hideConferenceSubject and hideConferenceTimer. Actually they are false.